### PR TITLE
Fix AES-GCM bound typo (7 != 9).

### DIFF
--- a/draft-wood-cfrg-aead-limits.md
+++ b/draft-wood-cfrg-aead-limits.md
@@ -211,20 +211,20 @@ and plaintext, as described in {{GCMProofs}}.
 ### Confidentiality Limit
 
 ~~~
-CA = ((s + q + 1)^2) / 2^127
+CA = ((s + q + 1)^2) / 2^129
 ~~~
 
 This implies the following usage limit:
 
 ~~~
-q + s <= p^(1/2) * 2^(127/2) - 1
+q + s <= p^(1/2) * 2^(129/2) - 1
 ~~~
 
 Which, for a message-based protocol with `s <= q * l`, if we assume that every
 packet is size `l`, produces the limit:
 
 ~~~
-q <= (p^(1/2) * 2^(127/2) - 1) / (l + 1)
+q <= (p^(1/2) * 2^(129/2) - 1) / (l + 1)
 ~~~
 
 ### Integrity Limit


### PR DESCRIPTION
cc @fxguenther 